### PR TITLE
Fixed the broken link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Each product has some basic usage instructions that will be printed with either
 the -h or --help options, e.g. `qimcdespot -h`. The majority of programs take
 the input filenames as arguments on the command-line, and in addition will read
 an input text file from `stdin`. For further details, see the 
-[documentation](https://spinicist.github.io/QUIT), which is also available in 
+[documentation](https://github.com/em-blue/QUIT/tree/master/Docs), which is also available in 
 the `Docs` folder.
 
 ## Getting Help


### PR DESCRIPTION
Hey Tobias, I've just fixed the link to documentation - https://spinicist.github.io/QUIT was broken/ did not exist so I've changed it to https://github.com/em-blue/QUIT/tree/master/Docs